### PR TITLE
fix: capture "this" for the closure's scope

### DIFF
--- a/MMM-GoogleTasks.js
+++ b/MMM-GoogleTasks.js
@@ -53,10 +53,13 @@ Module.register("MMM-GoogleTasks", {
     if (notification === "SERVICE_READY") {
       this.sendSocketNotification("REQUEST_UPDATE", this.config);
 
-      // Create repeating call to node_helper get list
+      // Create repeating call to node_helper get list.
+      // Must make a helper variable to capture "this" at the right scope.
+      // See https://github.com/MichMich/MagicMirror/issues/196#issuecomment-211565531
+      const self = this;
       setInterval(function () {
-        this.sendSocketNotification("REQUEST_UPDATE", this.config);
-      }, this.config.updateInterval);
+        self.sendSocketNotification("REQUEST_UPDATE", self.config);
+      }, self.config.updateInterval);
 
       // Check if payload id matches module id
     } else if (


### PR DESCRIPTION
This fixes a bug that stopped the module from updating anytime after the initial load. See this issue https://github.com/jgauth/MMM-GoogleTasks/issues/22 for more details.